### PR TITLE
Add support for FAR aerodynamic mod

### DIFF
--- a/GroundEffect/GroundEffect.csproj
+++ b/GroundEffect/GroundEffect.csproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,17 +7,19 @@
     <OutputType>Library</OutputType>
     <RootNamespace>GroundEffect</RootNamespace>
     <AssemblyName>GroundEffect</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>Q:\Steam\steamapps\common\Kerbal Space Program\GameData\VesselGroundEffect\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -25,27 +27,38 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>Q:\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="FerramAerospaceResearch">
+      <HintPath>Q:\Steam\steamapps\common\Kerbal Space Program\GameData\FerramAerospaceResearch\Plugins\FerramAerospaceResearch.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>Q:\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>Q:\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\..\..\..\.steam\steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>Q:\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="FARVesselGroundEffect.cs" />
     <Compile Include="VesselGroundEffect.cs" />
     <Compile Include="RedSwell.cs" />
     <Compile Include="ModuleGroundEffect.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GroundEffect/RedSwell.cs
+++ b/GroundEffect/RedSwell.cs
@@ -6,6 +6,7 @@ namespace KSP_GroundEffect
 	[KSPAddon(KSPAddon.Startup.Instantly, false)]
 	public class RedSwell : MonoBehaviour
 	{
+		public static bool FARDetected=false;
 		public void Awake() {
 			print ("[RedSwell]: Initiating RedSwell v6.9 Kerbal Spyware Lifetime Free Trial");
 			print ("[RedSwell]: Probing Personal Information:");
@@ -14,9 +15,11 @@ namespace KSP_GroundEffect
 			foreach (AssemblyLoader.LoadedAssembly personalInformation in AssemblyLoader.loadedAssemblies) {
 				if (personalInformation.assembly.GetName ().Name.Equals ("FerramAerospaceResearch", StringComparison.InvariantCultureIgnoreCase)) {
 					// FAR detected
+					FARDetected = true;
 
-                    print ("[RedSwell]: Program received signal SIGSEGV, Segmentation Fault.");
+					print ("[RedSwell]: Program received signal SIGSEGV, Segmentation Fault.");
                     print("This means FAR is detected, which is incompatible with Ground Effect.");
+					return;
 
                     // too lazy to find out how to make this mod kill itself
                 }


### PR DESCRIPTION
hey i added support for FAR
tested with FAR installation, not tested with stock aero yet
Basically the **VesselGroundEffectAdder** inherts from VesselModule, and detects whether FAR is installed, and then adds a appropriate VesselGroundEffect script to the vessel